### PR TITLE
Change "missing option" command exception code

### DIFF
--- a/src/CommandException.php
+++ b/src/CommandException.php
@@ -6,7 +6,7 @@ use RuntimeException;
 
 class CommandException extends RuntimeException
 {
-    const MISSING_OPTION = 5990;
+    const MISSING_OPTION = 500;
 
     /**
      * @param string $name


### PR DESCRIPTION
The previous code was specific to a usage and did not make sense as a
general error code.

Using `500` can be used as an HTTP status code and has no downsides for
other situations.

Replaces #1