### PR TITLE
Modify AbstractCommand to allow false-y option values

### DIFF
--- a/src/AbstractCommand.php
+++ b/src/AbstractCommand.php
@@ -18,7 +18,7 @@ abstract class AbstractCommand implements CommandInterface
 
         if ($required) {
             foreach ($required as $key) {
-                if (empty($this->options[$key])) {
+                if (!isset($this->options[$key])) {
                     throw CommandException::missingOption($key);
                 }
             }

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -81,7 +81,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
             ]);
 
         $command = $this->command->withOptions([
-            'user_id' => 42,
+            'user_id' => 0,
             'okay'    => true,
         ]);
 


### PR DESCRIPTION
Related discussion:

```
Matt Turland 4:35 PM
@shadowhand Is the argument you made here... https://github.com/wheniwork/api-data-layer/pull/25#discussion_r47857468 ... also potentially applicable here... https://github.com/sparkphp/command/blob/e22fa6a01139c3df5c5f99ed49dd077c632ec808/src/AbstractCommand.php#L21 ?

Woody Gilk 4:36 PM
yeah, i suppose so.
yes
definitely so... the description for requiredOptions says "must be defined"
which implies that 0 is a perfectly acceptable value
```